### PR TITLE
Add user module with admin & profile routes

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@db:5432/postgres

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,32 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from app.models import Base
+from app.core.config import settings
+
+config = context.config
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+fileConfig(config.config_file_name)
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=Base.metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=Base.metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_create_users.py
+++ b/alembic/versions/0001_create_users.py
@@ -1,0 +1,30 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(), nullable=True),
+        sa.Column('email', sa.String(), nullable=False, unique=True, index=True),
+        sa.Column('password_hash', sa.String(), nullable=False),
+        sa.Column('role', sa.String(), nullable=False, server_default='user'),
+        sa.Column('status', sa.String(), nullable=False, server_default='active'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('last_login', sa.DateTime(timezone=True)),
+        sa.Column('order_count', sa.Integer(), server_default='0'),
+        sa.Column('total_spent', sa.Float(), server_default='0'),
+        sa.Column('phone', sa.String()),
+        sa.Column('avatar', sa.String()),
+        sa.Column('is_professional', sa.Boolean(), server_default='false'),
+        sa.Column('professional_type', sa.String()),
+    )
+
+
+def downgrade():
+    op.drop_table('users')

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -1,0 +1,10 @@
+from fastapi import Depends, HTTPException
+from app.services.auth import get_current_user
+
+
+def require_role(role: str):
+    async def wrapper(user=Depends(get_current_user)):
+        if user.role != role:
+            raise HTTPException(status_code=403, detail="Accès administrateur requis.")
+        return user
+    return wrapper

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from fastapi_jwt_auth import AuthJWT
+
+from app.core.config import settings
+
+class AuthSettings(BaseModel):
+    authjwt_secret_key: str = settings.SECRET_KEY
+    authjwt_algorithm: str = settings.ALGORITHM
+
+@AuthJWT.load_config
+def get_config():
+    return AuthSettings()
+

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,3 +1,3 @@
-from .session import get_session, engine
+from .session import get_session, engine, async_session
 
-__all__ = ["get_session", "engine"]
+__all__ = ["get_session", "engine", "async_session"]

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, DateTime, Float, Boolean
 from sqlalchemy.orm import declarative_base
+from sqlalchemy.sql import func
 
 Base = declarative_base()
 
@@ -7,5 +8,16 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=True)
     email = Column(String, unique=True, index=True, nullable=False)
-    hashed_password = Column(String, nullable=False)
+    password_hash = Column(String, nullable=False)
+    role = Column(String, default="user", nullable=False)
+    status = Column(String, default="active", nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_login = Column(DateTime(timezone=True), nullable=True)
+    order_count = Column(Integer, default=0)
+    total_spent = Column(Float, default=0.0)
+    phone = Column(String, nullable=True)
+    avatar = Column(String, nullable=True)
+    is_professional = Column(Boolean, default=False)
+    professional_type = Column(String, nullable=True)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
 
-from . import auth
+from . import auth, profile
+from .admin import users as admin_users
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
-
-__all__ = ["api_router", "auth"]
+api_router.include_router(profile.router, tags=["profile"])
+api_router.include_router(admin_users.router, tags=["admin"])
+__all__ = ["api_router", "auth", "profile", "admin_users"]

--- a/app/routers/admin/__init__.py
+++ b/app/routers/admin/__init__.py
@@ -1,0 +1,3 @@
+from . import users
+
+__all__ = ["users"]

--- a/app/routers/admin/users.py
+++ b/app/routers/admin/users.py
@@ -1,0 +1,52 @@
+from typing import Optional
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import UserPage, StatusUpdate, RoleUpdate
+from app.services import user_service
+from app.core.dependencies import require_role
+
+router = APIRouter()
+
+@router.get("/api/admin/users", response_model=UserPage)
+async def list_users(
+    page: int = 1,
+    limit: int = 10,
+    role: Optional[str] = None,
+    status: Optional[str] = None,
+    search: Optional[str] = None,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    users, total = await user_service.find_all(session, page, limit, role, status, search)
+    return {"users": users, "total": total, "page": page, "limit": limit}
+
+@router.put("/api/admin/users/{user_id}/status")
+async def update_user_status(
+    user_id: int,
+    data: StatusUpdate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    await user_service.update_status(session, user_id, data.status, data.reason)
+    return {"message": "Statut de l'utilisateur modifié avec succès."}
+
+@router.put("/api/admin/users/{user_id}/role")
+async def update_user_role(
+    user_id: int,
+    data: RoleUpdate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    await user_service.update_role(session, user_id, data.role, data.permissions)
+    return {"message": "Rôle de l'utilisateur modifié avec succès."}
+
+@router.delete("/api/admin/users/{user_id}")
+async def delete_user(
+    user_id: int,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    await user_service.remove(session, user_id)
+    return {"message": "Utilisateur supprimé avec succès."}

--- a/app/routers/profile.py
+++ b/app/routers/profile.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import ProfileOut, ProfileUpdate
+from app.services import user_service
+from app.services.auth import get_current_user
+
+router = APIRouter()
+
+@router.get("/api/profile", response_model=ProfileOut)
+async def read_profile(user=Depends(get_current_user)):
+    return user
+
+@router.put("/api/profile", response_model=ProfileOut)
+async def update_profile(
+    data: ProfileUpdate,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+):
+    updated = await user_service.update_profile(session, user.id, data.name, data.phone, data.avatar)
+    return updated

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,3 +1,21 @@
 from .auth import UserCreate, UserOut, Token
+from .user import (
+    UserBase,
+    UserPage,
+    StatusUpdate,
+    RoleUpdate,
+    ProfileOut,
+    ProfileUpdate,
+)
 
-__all__ = ["UserCreate", "UserOut", "Token"]
+__all__ = [
+    "UserCreate",
+    "UserOut",
+    "Token",
+    "UserBase",
+    "UserPage",
+    "StatusUpdate",
+    "RoleUpdate",
+    "ProfileOut",
+    "ProfileUpdate",
+]

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,52 @@
+from typing import Optional, List
+from datetime import datetime
+from pydantic import BaseModel, EmailStr
+
+class UserBase(BaseModel):
+    id: int
+    name: Optional[str]
+    email: EmailStr
+    role: str
+    status: str
+    created_at: datetime
+    last_login: Optional[datetime]
+    order_count: int
+    total_spent: float
+    phone: Optional[str]
+    avatar: Optional[str]
+    is_professional: bool
+    professional_type: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+class UserPage(BaseModel):
+    users: List[UserBase]
+    total: int
+    page: int
+    limit: int
+
+class StatusUpdate(BaseModel):
+    status: str
+    reason: Optional[str]
+
+class RoleUpdate(BaseModel):
+    role: str
+    permissions: Optional[List[str]] = None
+
+class ProfileOut(BaseModel):
+    id: int
+    name: Optional[str]
+    email: EmailStr
+    is_professional: bool
+    professional_type: Optional[str]
+    avatar: Optional[str]
+    phone: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+class ProfileUpdate(BaseModel):
+    name: str
+    phone: Optional[str] = None
+    avatar: Optional[str] = None

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import auth
+from . import auth, user_service
 
-__all__ = ["auth"]
+__all__ = ["auth", "user_service"]

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -3,11 +3,17 @@ from typing import Optional
 
 import bcrypt
 import jwt
+from fastapi import Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer
+from fastapi_jwt_auth import AuthJWT
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from app.core.config import settings
 from app.models import User
+from app.db.session import get_session
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
 
 async def get_user_by_email(session: AsyncSession, email: str) -> Optional[User]:
     result = await session.execute(select(User).where(User.email == email))
@@ -15,7 +21,7 @@ async def get_user_by_email(session: AsyncSession, email: str) -> Optional[User]
 
 async def create_user(session: AsyncSession, email: str, password: str) -> User:
     hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
-    user = User(email=email, hashed_password=hashed)
+    user = User(email=email, password_hash=hashed)
     session.add(user)
     await session.commit()
     await session.refresh(user)
@@ -25,7 +31,7 @@ async def authenticate_user(session: AsyncSession, email: str, password: str) ->
     user = await get_user_by_email(session, email)
     if not user:
         return None
-    if not bcrypt.checkpw(password.encode(), user.hashed_password.encode()):
+    if not bcrypt.checkpw(password.encode(), user.password_hash.encode()):
         return None
     return user
 
@@ -34,3 +40,18 @@ def create_access_token(subject: str, expires_delta: int = settings.ACCESS_TOKEN
     expire = datetime.utcnow() + timedelta(minutes=expires_delta)
     to_encode = {"sub": subject, "exp": expire}
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+async def get_current_user(
+    Authorize: AuthJWT = Depends(),
+    session: AsyncSession = Depends(get_session),
+) -> User:
+    try:
+        Authorize.jwt_required()
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    user_id = Authorize.get_jwt_subject()
+    result = await session.execute(select(User).where(User.id == int(user_id)))
+    user = result.scalars().first()
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return user

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,0 +1,61 @@
+from typing import Optional, Tuple, List
+
+from sqlalchemy.future import select
+from sqlalchemy import update, delete, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import HTTPException
+
+from app.models import User
+
+async def find_all(
+    session: AsyncSession,
+    page: int,
+    limit: int,
+    role: Optional[str] = None,
+    status: Optional[str] = None,
+    search: Optional[str] = None,
+) -> Tuple[List[User], int]:
+    query = select(User)
+    if role:
+        query = query.where(User.role == role)
+    if status:
+        query = query.where(User.status == status)
+    if search:
+        term = f"%{search}%"
+        query = query.where(User.name.ilike(term))
+    count_query = select(func.count()).select_from(query.subquery())
+    total = await session.scalar(count_query)
+    result = await session.execute(query.offset((page - 1) * limit).limit(limit))
+    return result.scalars().all(), total or 0
+
+async def update_status(session: AsyncSession, user_id: int, status: str, reason: str) -> None:
+    result = await session.execute(select(User).where(User.id == user_id))
+    user = result.scalars().first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Utilisateur non trouvé.")
+    user.status = status
+    await session.commit()
+
+async def update_role(session: AsyncSession, user_id: int, role: str, permissions: Optional[list]) -> None:
+    result = await session.execute(select(User).where(User.id == user_id))
+    user = result.scalars().first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Utilisateur non trouvé.")
+    user.role = role
+    await session.commit()
+
+async def remove(session: AsyncSession, user_id: int) -> None:
+    await session.execute(delete(User).where(User.id == user_id))
+    await session.commit()
+
+async def update_profile(session: AsyncSession, user_id: int, name: str, phone: Optional[str], avatar: Optional[str]) -> User:
+    result = await session.execute(select(User).where(User.id == user_id))
+    user = result.scalars().first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Utilisateur non trouvé.")
+    user.name = name
+    user.phone = phone
+    user.avatar = avatar
+    await session.commit()
+    await session.refresh(user)
+    return user

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ bcrypt
 PyJWT
 pytest
 httpx
+fastapi-jwt-auth

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,42 @@
+import pytest
+from httpx import AsyncClient
+
+from app.main import app
+from app.db.session import engine, async_session
+from app.models import Base
+from app.services.auth import create_user, create_access_token
+
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.mark.asyncio
+async def test_profile_and_admin():
+    async with async_session() as session:
+        admin = await create_user(session, "admin@test.com", "pass")
+        admin.role = "admin"
+        user = await create_user(session, "user@test.com", "pass")
+        await session.commit()
+        token_admin = create_access_token(str(admin.id))
+        token_user = create_access_token(str(user.id))
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        headers_admin = {"Authorization": f"Bearer {token_admin}"}
+        resp = await ac.get("/api/admin/users", headers=headers_admin)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "users" in data
+
+        resp = await ac.put(f"/api/admin/users/{user.id}/status", json={"status": "suspended"}, headers=headers_admin)
+        assert resp.status_code == 200
+
+        headers_user = {"Authorization": f"Bearer {token_user}"}
+        resp = await ac.get("/api/profile", headers=headers_user)
+        assert resp.status_code == 200
+        resp = await ac.put("/api/profile", json={"name": "Tester"}, headers=headers_user)
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Tester"


### PR DESCRIPTION
## Summary
- implement full User model with roles and status
- configure Alembic for database migrations
- add JWT security utilities and role dependency
- create user service with admin CRUD helpers
- expose admin and profile API routes
- provide Pydantic schemas for user operations
- extend tests covering user endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685e9ec3e514832cab71464b7702ebf9