### PR TITLE
Add categories module

### DIFF
--- a/alembic/versions/0002_create_categories.py
+++ b/alembic/versions/0002_create_categories.py
@@ -1,0 +1,23 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'categories',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('name', sa.String(), nullable=False, unique=True),
+        sa.Column('description', sa.String(), nullable=True),
+        sa.Column('parent_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('categories.id'), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table('categories')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,4 @@
 from .user import User, Base
+from .category import Category
 
-__all__ = ["User", "Base"]
+__all__ = ["User", "Base", "Category"]

--- a/app/models/category.py
+++ b/app/models/category.py
@@ -1,0 +1,23 @@
+import uuid
+from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship, backref
+
+from .user import Base
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, unique=True, nullable=False)
+    description = Column(String, nullable=True)
+    parent_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    children = relationship(
+        "Category",
+        backref=backref("parent", remote_side=[id]),
+        cascade="all, delete-orphan",
+    )

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter
 
-from . import auth, profile
-from .admin import users as admin_users
+from . import auth, profile, categories
+from .admin import users as admin_users, categories as admin_categories
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(profile.router, tags=["profile"])
+api_router.include_router(categories.router, tags=["categories"])
 api_router.include_router(admin_users.router, tags=["admin"])
-__all__ = ["api_router", "auth", "profile", "admin_users"]
+api_router.include_router(admin_categories.router, tags=["admin"])
+__all__ = ["api_router", "auth", "profile", "categories", "admin_users", "admin_categories"]

--- a/app/routers/admin/__init__.py
+++ b/app/routers/admin/__init__.py
@@ -1,3 +1,3 @@
-from . import users
+from . import users, categories
 
-__all__ = ["users"]
+__all__ = ["users", "categories"]

--- a/app/routers/admin/categories.py
+++ b/app/routers/admin/categories.py
@@ -1,0 +1,36 @@
+from uuid import UUID
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import CategoryBase, CategoryCreate, CategoryUpdate
+from app.services import categories as category_service
+from app.core.dependencies import require_role
+
+router = APIRouter()
+
+@router.post("/api/admin/categories", response_model=CategoryBase, status_code=status.HTTP_201_CREATED)
+async def create_category(
+    data: CategoryCreate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await category_service.create(session, data)
+
+@router.put("/api/admin/categories/{category_id}", response_model=CategoryBase)
+async def update_category(
+    category_id: UUID,
+    data: CategoryUpdate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await category_service.update(session, category_id, data)
+
+@router.delete("/api/admin/categories/{category_id}")
+async def delete_category(
+    category_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    await category_service.remove(session, category_id)
+    return {"message": "Catégorie supprimée avec succès."}

--- a/app/routers/categories.py
+++ b/app/routers/categories.py
@@ -1,0 +1,32 @@
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import CategoryPage, CategoryBase, CategoryTree
+from app.services import categories as category_service
+
+router = APIRouter()
+
+@router.get("/api/categories", response_model=CategoryPage)
+async def list_categories(
+    page: int = 1,
+    limit: int = 10,
+    search: Optional[str] = None,
+    session: AsyncSession = Depends(get_session),
+):
+    categories, total = await category_service.find_all(session, page, limit, search)
+    return {"categories": categories, "total": total, "page": page, "limit": limit}
+
+@router.get("/api/categories/{category_id}", response_model=CategoryBase)
+async def get_category(
+    category_id: UUID,
+    session: AsyncSession = Depends(get_session),
+):
+    return await category_service.find_one(session, category_id)
+
+@router.get("/api/categories/tree", response_model=list[CategoryTree])
+async def get_tree(session: AsyncSession = Depends(get_session)):
+    return await category_service.find_tree(session)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -7,6 +7,13 @@ from .user import (
     ProfileOut,
     ProfileUpdate,
 )
+from .category import (
+    CategoryBase,
+    CategoryCreate,
+    CategoryUpdate,
+    CategoryPage,
+    CategoryTree,
+)
 
 __all__ = [
     "UserCreate",
@@ -18,4 +25,9 @@ __all__ = [
     "RoleUpdate",
     "ProfileOut",
     "ProfileUpdate",
+    "CategoryBase",
+    "CategoryCreate",
+    "CategoryUpdate",
+    "CategoryPage",
+    "CategoryTree",
 ]

--- a/app/schemas/category.py
+++ b/app/schemas/category.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+class CategoryBase(BaseModel):
+    id: UUID
+    name: str
+    description: Optional[str] = None
+    parent_id: Optional[UUID] = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+class CategoryCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    parent_id: Optional[UUID] = None
+
+class CategoryUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    parent_id: Optional[UUID] = None
+
+class CategoryPage(BaseModel):
+    categories: List[CategoryBase]
+    total: int
+    page: int
+    limit: int
+
+class CategoryTree(CategoryBase):
+    children: List['CategoryTree'] = []
+
+CategoryTree.update_forward_refs()

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import auth, user_service
+from . import auth, user_service, categories
 
-__all__ = ["auth", "user_service"]
+__all__ = ["auth", "user_service", "categories"]

--- a/app/services/categories.py
+++ b/app/services/categories.py
@@ -1,0 +1,75 @@
+from typing import List, Optional, Tuple
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import select, func, update, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Category
+
+async def find_all(
+    session: AsyncSession,
+    page: int,
+    limit: int,
+    search: Optional[str] = None,
+) -> Tuple[List[Category], int]:
+    query = select(Category)
+    if search:
+        term = f"%{search}%"
+        query = query.where(Category.name.ilike(term))
+    count_query = select(func.count()).select_from(query.subquery())
+    total = await session.scalar(count_query)
+    result = await session.execute(
+        query.order_by(Category.created_at.desc())
+        .offset((page - 1) * limit)
+        .limit(limit)
+    )
+    return result.scalars().all(), total or 0
+
+async def find_one(session: AsyncSession, category_id: UUID) -> Category:
+    result = await session.execute(select(Category).where(Category.id == category_id))
+    category = result.scalars().first()
+    if not category:
+        raise HTTPException(status_code=404, detail="Catégorie non trouvée.")
+    return category
+
+async def create(session: AsyncSession, data) -> Category:
+    category = Category(**data.dict())
+    session.add(category)
+    await session.commit()
+    await session.refresh(category)
+    return category
+
+async def update(session: AsyncSession, category_id: UUID, data) -> Category:
+    result = await session.execute(select(Category).where(Category.id == category_id))
+    category = result.scalars().first()
+    if not category:
+        raise HTTPException(status_code=404, detail="Catégorie non trouvée.")
+    for key, value in data.dict(exclude_unset=True).items():
+        setattr(category, key, value)
+    await session.commit()
+    await session.refresh(category)
+    return category
+
+async def remove(session: AsyncSession, category_id: UUID, soft_delete: bool = True) -> None:
+    result = await session.execute(select(Category).where(Category.id == category_id))
+    category = result.scalars().first()
+    if not category:
+        raise HTTPException(status_code=404, detail="Catégorie non trouvée.")
+    await session.delete(category)
+    await session.commit()
+
+async def find_tree(session: AsyncSession) -> List[dict]:
+    result = await session.execute(select(Category))
+    categories = result.scalars().all()
+    mapping = {c.id: {"id": str(c.id), "name": c.name, "description": c.description, "parent_id": str(c.parent_id) if c.parent_id else None, "children": []} for c in categories}
+    roots = []
+    for cat in categories:
+        node = mapping[cat.id]
+        if cat.parent_id:
+            parent = mapping.get(cat.parent_id)
+            if parent:
+                parent["children"].append(node)
+        else:
+            roots.append(node)
+    return roots

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,71 @@
+import pytest
+from httpx import AsyncClient
+from uuid import UUID
+
+from app.main import app
+from app.db.session import engine, async_session
+from app.models import Base
+from app.services.auth import create_user, create_access_token
+
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.mark.asyncio
+async def test_categories_crud():
+    async with async_session() as session:
+        admin = await create_user(session, "admin2@test.com", "pass")
+        admin.role = "admin"
+        user = await create_user(session, "user2@test.com", "pass")
+        await session.commit()
+        token_admin = create_access_token(str(admin.id))
+        token_user = create_access_token(str(user.id))
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        # unauthorized
+        resp = await ac.post("/api/admin/categories", json={"name": "test"})
+        assert resp.status_code == 401
+
+        headers_admin = {"Authorization": f"Bearer {token_admin}"}
+        headers_user = {"Authorization": f"Bearer {token_user}"}
+
+        # forbidden for regular user
+        resp = await ac.post("/api/admin/categories", json={"name": "test"}, headers=headers_user)
+        assert resp.status_code == 403
+
+        # create
+        resp = await ac.post("/api/admin/categories", json={"name": "Electronics"}, headers=headers_admin)
+        assert resp.status_code == 201
+        cat_id = resp.json()["id"]
+
+        # list
+        resp = await ac.get("/api/categories")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+        # get
+        resp = await ac.get(f"/api/categories/{cat_id}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Electronics"
+
+        # update
+        resp = await ac.put(f"/api/admin/categories/{cat_id}", json={"description": "Desc"}, headers=headers_admin)
+        assert resp.status_code == 200
+        assert resp.json()["description"] == "Desc"
+
+        # tree
+        resp = await ac.get("/api/categories/tree")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+        # delete
+        resp = await ac.delete(f"/api/admin/categories/{cat_id}", headers=headers_admin)
+        assert resp.status_code == 200
+
+        # not found
+        resp = await ac.get(f"/api/categories/{cat_id}")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add Category SQLAlchemy model
- create Alembic migration for categories table
- implement CRUD service for categories
- add routers for public and admin category endpoints
- create Pydantic schemas for categories
- include categories in API router configuration
- add pytest coverage for categories endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685ea1691940832c91ab41acc8a68bf8