### PR TITLE
Add products module with FastAPI

### DIFF
--- a/alembic/versions/0003_create_products.py
+++ b/alembic/versions/0003_create_products.py
@@ -1,0 +1,28 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'products',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('price', sa.Float(), nullable=False),
+        sa.Column('category_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('categories.id'), nullable=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=True),
+        sa.Column('images', postgresql.ARRAY(sa.String()), nullable=True),
+        sa.Column('stock', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('status', sa.String(), nullable=False, server_default='pending'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table('products')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,5 @@
 from .user import User, Base
 from .category import Category
+from .product import Product
 
-__all__ = ["User", "Base", "Category"]
+__all__ = ["User", "Base", "Category", "Product"]

--- a/app/models/product.py
+++ b/app/models/product.py
@@ -1,0 +1,31 @@
+import uuid
+from enum import Enum
+from sqlalchemy import Column, String, Text, Float, Integer, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, ARRAY
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from .user import Base
+
+class ProductStatus(str, Enum):
+    active = "active"
+    inactive = "inactive"
+    pending = "pending"
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    price = Column(Float, nullable=False)
+    category_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    images = Column(ARRAY(String), nullable=True)
+    stock = Column(Integer, nullable=False, default=0)
+    status = Column(String, nullable=False, default=ProductStatus.pending.value)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    category = relationship("Category", backref="products")
+    seller = relationship("User", backref="products")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,12 +1,26 @@
 from fastapi import APIRouter
 
-from . import auth, profile, categories
-from .admin import users as admin_users, categories as admin_categories
+from . import auth, profile, categories, products
+from .professional import products as professional_products
+from .admin import users as admin_users, categories as admin_categories, products as admin_products
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(profile.router, tags=["profile"])
 api_router.include_router(categories.router, tags=["categories"])
+api_router.include_router(products.router, tags=["products"])
 api_router.include_router(admin_users.router, tags=["admin"])
 api_router.include_router(admin_categories.router, tags=["admin"])
-__all__ = ["api_router", "auth", "profile", "categories", "admin_users", "admin_categories"]
+api_router.include_router(admin_products.router, tags=["admin"])
+api_router.include_router(professional_products.router, tags=["professional"])
+__all__ = [
+    "api_router",
+    "auth",
+    "profile",
+    "categories",
+    "products",
+    "admin_users",
+    "admin_categories",
+    "admin_products",
+    "professional_products",
+]

--- a/app/routers/admin/__init__.py
+++ b/app/routers/admin/__init__.py
@@ -1,3 +1,3 @@
-from . import users, categories
+from . import users, categories, products
 
-__all__ = ["users", "categories"]
+__all__ = ["users", "categories", "products"]

--- a/app/routers/admin/products.py
+++ b/app/routers/admin/products.py
@@ -1,0 +1,63 @@
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import (
+    ProductBase,
+    ProductUpdate,
+    ProductPage,
+    ProductStatusUpdate,
+)
+from app.services import products as product_service
+from app.core.dependencies import require_role
+
+router = APIRouter()
+
+@router.get("/api/admin/products", response_model=ProductPage)
+async def list_products(
+    page: int = 1,
+    limit: int = 20,
+    status: Optional[str] = None,
+    category_id: Optional[UUID] = None,
+    user_id: Optional[int] = None,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    products, total = await product_service.find_all_public(
+        session, page, limit, category_id
+    )
+    if status:
+        products = [p for p in products if p.status == status]
+    if user_id:
+        products = [p for p in products if p.user_id == user_id]
+    return {"products": products, "total": total, "page": page, "limit": limit}
+
+@router.put("/api/admin/products/{product_id}/status", response_model=ProductBase)
+async def change_status(
+    product_id: UUID,
+    data: ProductStatusUpdate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await product_service.update_status(session, product_id, data.status.value, data.reason)
+
+@router.put("/api/admin/products/{product_id}", response_model=ProductBase)
+async def update_product(
+    product_id: UUID,
+    data: ProductUpdate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await product_service.update(session, product_id, data)
+
+@router.delete("/api/admin/products/{product_id}")
+async def delete_product(
+    product_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    await product_service.remove(session, product_id)
+    return {"message": "Produit supprimé"}

--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -1,0 +1,30 @@
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import ProductPage, ProductBase
+from app.services import products as product_service
+
+router = APIRouter()
+
+@router.get("/api/products", response_model=ProductPage)
+async def list_products(
+    page: int = 1,
+    limit: int = 12,
+    category_id: Optional[UUID] = None,
+    search: Optional[str] = None,
+    min_price: Optional[float] = None,
+    max_price: Optional[float] = None,
+    session: AsyncSession = Depends(get_session),
+):
+    products, total = await product_service.find_all_public(
+        session, page, limit, category_id, search, min_price, max_price
+    )
+    return {"products": products, "total": total, "page": page, "limit": limit}
+
+@router.get("/api/products/{product_id}", response_model=ProductBase)
+async def get_product(product_id: UUID, session: AsyncSession = Depends(get_session)):
+    return await product_service.find_one(session, product_id)

--- a/app/routers/professional/__init__.py
+++ b/app/routers/professional/__init__.py
@@ -1,0 +1,3 @@
+from . import products
+
+__all__ = ["products"]

--- a/app/routers/professional/products.py
+++ b/app/routers/professional/products.py
@@ -1,0 +1,56 @@
+from uuid import UUID
+from typing import Optional
+
+from fastapi import APIRouter, Depends, status, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import ProductBase, ProductCreate, ProductUpdate, ProductPage
+from app.services import products as product_service
+from app.core.dependencies import require_role
+
+router = APIRouter()
+
+@router.post("/api/professional/products", response_model=ProductBase, status_code=status.HTTP_201_CREATED)
+async def create_product(
+    data: ProductCreate,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("professional")),
+):
+    data.user_id = user.id
+    return await product_service.create(session, data)
+
+@router.put("/api/professional/products/{product_id}", response_model=ProductBase)
+async def update_product(
+    product_id: UUID,
+    data: ProductUpdate,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("professional")),
+):
+    product = await product_service.find_one(session, product_id)
+    if product.user_id != user.id:
+        raise HTTPException(status_code=403, detail="Accès refusé")
+    return await product_service.update(session, product_id, data)
+
+@router.delete("/api/professional/products/{product_id}")
+async def delete_product(
+    product_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("professional")),
+):
+    product = await product_service.find_one(session, product_id)
+    if product.user_id != user.id:
+        raise HTTPException(status_code=403, detail="Accès refusé")
+    await product_service.remove(session, product_id)
+    return {"message": "Produit supprimé"}
+
+@router.get("/api/professional/products", response_model=ProductPage)
+async def list_my_products(
+    page: int = 1,
+    limit: int = 10,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_role("professional")),
+):
+    products, total = await product_service.find_all_public(session, page, limit)
+    products = [p for p in products if p.user_id == user.id]
+    return {"products": products, "total": total, "page": page, "limit": limit}

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -14,6 +14,13 @@ from .category import (
     CategoryPage,
     CategoryTree,
 )
+from .product import (
+    ProductBase,
+    ProductCreate,
+    ProductUpdate,
+    ProductPage,
+    StatusUpdate as ProductStatusUpdate,
+)
 
 __all__ = [
     "UserCreate",
@@ -30,4 +37,9 @@ __all__ = [
     "CategoryUpdate",
     "CategoryPage",
     "CategoryTree",
+    "ProductBase",
+    "ProductCreate",
+    "ProductUpdate",
+    "ProductPage",
+    "ProductStatusUpdate",
 ]

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from app.models.product import ProductStatus
+
+class ProductBase(BaseModel):
+    id: UUID
+    name: str
+    description: Optional[str] = None
+    price: float
+    category_id: Optional[UUID] = None
+    user_id: Optional[int] = None
+    images: Optional[List[str]] = None
+    stock: int
+    status: ProductStatus
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+class ProductCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    price: float
+    category_id: Optional[UUID] = None
+    user_id: Optional[int] = None
+    images: Optional[List[str]] = None
+    stock: int
+    status: Optional[ProductStatus] = ProductStatus.pending
+
+class ProductUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    price: Optional[float] = None
+    category_id: Optional[UUID] = None
+    images: Optional[List[str]] = None
+    stock: Optional[int] = None
+    status: Optional[ProductStatus] = None
+
+class ProductPage(BaseModel):
+    products: List[ProductBase]
+    total: int
+    page: int
+    limit: int
+
+class StatusUpdate(BaseModel):
+    status: ProductStatus
+    reason: Optional[str] = None

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import auth, user_service, categories
+from . import auth, user_service, categories, products
 
-__all__ = ["auth", "user_service", "categories"]
+__all__ = ["auth", "user_service", "categories", "products"]

--- a/app/services/products.py
+++ b/app/services/products.py
@@ -1,0 +1,77 @@
+from typing import List, Optional, Tuple
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import select, func, update, delete, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Product, ProductStatus
+
+async def find_all_public(
+    session: AsyncSession,
+    page: int,
+    limit: int,
+    category_id: Optional[UUID] = None,
+    search: Optional[str] = None,
+    min_price: Optional[float] = None,
+    max_price: Optional[float] = None,
+) -> Tuple[List[Product], int]:
+    query = select(Product).where(Product.status == ProductStatus.active.value)
+    if category_id:
+        query = query.where(Product.category_id == category_id)
+    if search:
+        term = f"%{search}%"
+        query = query.where(or_(Product.name.ilike(term), Product.description.ilike(term)))
+    if min_price is not None:
+        query = query.where(Product.price >= min_price)
+    if max_price is not None:
+        query = query.where(Product.price <= max_price)
+    count_query = select(func.count()).select_from(query.subquery())
+    total = await session.scalar(count_query)
+    result = await session.execute(
+        query.order_by(Product.created_at.desc()).offset((page - 1) * limit).limit(limit)
+    )
+    return result.scalars().all(), total or 0
+
+async def find_one(session: AsyncSession, product_id: UUID) -> Product:
+    result = await session.execute(select(Product).where(Product.id == product_id))
+    product = result.scalars().first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Produit non trouvé.")
+    return product
+
+async def create(session: AsyncSession, data) -> Product:
+    product = Product(**data.dict())
+    session.add(product)
+    await session.commit()
+    await session.refresh(product)
+    return product
+
+async def update(session: AsyncSession, product_id: UUID, data) -> Product:
+    result = await session.execute(select(Product).where(Product.id == product_id))
+    product = result.scalars().first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Produit non trouvé.")
+    for key, value in data.dict(exclude_unset=True).items():
+        setattr(product, key, value)
+    await session.commit()
+    await session.refresh(product)
+    return product
+
+async def remove(session: AsyncSession, product_id: UUID) -> None:
+    result = await session.execute(select(Product).where(Product.id == product_id))
+    product = result.scalars().first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Produit non trouvé.")
+    await session.delete(product)
+    await session.commit()
+
+async def update_status(session: AsyncSession, product_id: UUID, status: str, reason: Optional[str]) -> Product:
+    result = await session.execute(select(Product).where(Product.id == product_id))
+    product = result.scalars().first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Produit non trouvé.")
+    product.status = status
+    await session.commit()
+    await session.refresh(product)
+    return product

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,0 +1,80 @@
+import pytest
+from httpx import AsyncClient
+from uuid import UUID
+
+from app.main import app
+from app.db.session import engine, async_session
+from app.models import Base
+from app.services.auth import create_user, create_access_token
+
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.mark.asyncio
+async def test_products_crud():
+    async with async_session() as session:
+        admin = await create_user(session, "admin3@test.com", "pass")
+        admin.role = "admin"
+        pro = await create_user(session, "pro@test.com", "pass")
+        pro.role = "professional"
+        await session.commit()
+        token_admin = create_access_token(str(admin.id))
+        token_pro = create_access_token(str(pro.id))
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        headers_pro = {"Authorization": f"Bearer {token_pro}"}
+        headers_admin = {"Authorization": f"Bearer {token_admin}"}
+
+        # unauthorized create
+        resp = await ac.post("/api/professional/products", json={"name": "Prod", "price": 10, "stock": 5})
+        assert resp.status_code == 401
+
+        # create
+        resp = await ac.post(
+            "/api/professional/products",
+            json={"name": "Prod", "price": 10, "stock": 5},
+            headers=headers_pro,
+        )
+        assert resp.status_code == 201
+        prod_id = resp.json()["id"]
+
+        # list public
+        resp = await ac.get("/api/products")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+        # get
+        resp = await ac.get(f"/api/products/{prod_id}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Prod"
+
+        # update
+        resp = await ac.put(
+            f"/api/professional/products/{prod_id}",
+            json={"price": 15},
+            headers=headers_pro,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["price"] == 15
+
+        # admin change status
+        resp = await ac.put(
+            f"/api/admin/products/{prod_id}/status",
+            json={"status": "inactive"},
+            headers=headers_admin,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "inactive"
+
+        # delete
+        resp = await ac.delete(f"/api/professional/products/{prod_id}", headers=headers_pro)
+        assert resp.status_code == 200
+
+        # not found
+        resp = await ac.get(f"/api/products/{prod_id}")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- define Product model and Alembic migration
- implement product service CRUD operations
- add public, professional and admin routers
- expose product schemas
- include product tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685ea36c64c8832cb1f2c269fb5b45a8