### PR TITLE
Add orders module with CRUD endpoints

### DIFF
--- a/alembic/versions/0004_create_orders.py
+++ b/alembic/versions/0004_create_orders.py
@@ -1,0 +1,23 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0004'
+down_revision = '0003'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'orders',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('items', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('total', sa.Float(), nullable=False, server_default='0'),
+        sa.Column('status', sa.String(), nullable=False, server_default='pending'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+def downgrade():
+    op.drop_table('orders')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 from .user import User, Base
 from .category import Category
 from .product import Product
+from .order import Order
 
-__all__ = ["User", "Base", "Category", "Product"]
+__all__ = ["User", "Base", "Category", "Product", "Order"]

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -1,0 +1,31 @@
+import uuid
+from enum import Enum
+from sqlalchemy import Column, DateTime, Float, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from .user import Base, User
+
+class OrderStatus(str, Enum):
+    pending = "pending"
+    paid = "paid"
+    shipped = "shipped"
+    delivered = "delivered"
+
+class Order(Base):
+    __tablename__ = "orders"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(ForeignKey("users.id"), nullable=False)
+    items = Column(JSONB, nullable=False)
+    total = Column(Float, nullable=False, default=0.0)
+    status = Column(String, nullable=False, default=OrderStatus.pending.value)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    user = relationship(User)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,17 +1,24 @@
 from fastapi import APIRouter
 
-from . import auth, profile, categories, products
+from . import auth, profile, categories, products, orders
 from .professional import products as professional_products
-from .admin import users as admin_users, categories as admin_categories, products as admin_products
+from .admin import (
+    users as admin_users,
+    categories as admin_categories,
+    products as admin_products,
+    orders as admin_orders,
+)
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(profile.router, tags=["profile"])
 api_router.include_router(categories.router, tags=["categories"])
 api_router.include_router(products.router, tags=["products"])
+api_router.include_router(orders.router, tags=["orders"])
 api_router.include_router(admin_users.router, tags=["admin"])
 api_router.include_router(admin_categories.router, tags=["admin"])
 api_router.include_router(admin_products.router, tags=["admin"])
+api_router.include_router(admin_orders.router, tags=["admin"])
 api_router.include_router(professional_products.router, tags=["professional"])
 __all__ = [
     "api_router",
@@ -19,8 +26,10 @@ __all__ = [
     "profile",
     "categories",
     "products",
+    "orders",
     "admin_users",
     "admin_categories",
     "admin_products",
+    "admin_orders",
     "professional_products",
 ]

--- a/app/routers/admin/__init__.py
+++ b/app/routers/admin/__init__.py
@@ -1,3 +1,3 @@
-from . import users, categories, products
+from . import users, categories, products, orders
 
-__all__ = ["users", "categories", "products"]
+__all__ = ["users", "categories", "products", "orders"]

--- a/app/routers/admin/orders.py
+++ b/app/routers/admin/orders.py
@@ -1,0 +1,32 @@
+from uuid import UUID
+from typing import Optional
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import OrderBase, OrderPage, OrderStatusUpdate
+from app.services import orders as order_service
+from app.core.dependencies import require_role
+from app.models.order import OrderStatus
+
+router = APIRouter()
+
+@router.get("/api/admin/orders", response_model=OrderPage)
+async def list_orders_admin(
+    page: int = 1,
+    limit: int = 20,
+    status: Optional[OrderStatus] = None,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    orders, total = await order_service.find_all_admin(session, page, limit, status)
+    return {"orders": orders, "total": total, "page": page, "limit": limit}
+
+@router.put("/api/admin/orders/{order_id}/status", response_model=OrderBase)
+async def change_order_status(
+    order_id: UUID,
+    data: OrderStatusUpdate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await order_service.update_status(session, order_id, data.status)

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -1,0 +1,40 @@
+from uuid import UUID
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import OrderBase, OrderCreate, OrderPage
+from app.services import orders as order_service
+from app.services.auth import get_current_user
+
+router = APIRouter()
+
+@router.post("/api/orders", response_model=OrderBase, status_code=status.HTTP_201_CREATED)
+async def create_order(
+    data: OrderCreate,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+):
+    return await order_service.create_order(session, user.id, data)
+
+@router.get("/api/orders", response_model=OrderPage)
+async def list_orders(
+    page: int = 1,
+    limit: int = 10,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+):
+    orders, total = await order_service.find_all_by_user(session, user.id, page, limit)
+    return {"orders": orders, "total": total, "page": page, "limit": limit}
+
+@router.get("/api/orders/{order_id}", response_model=OrderBase)
+async def get_order(
+    order_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+):
+    order = await order_service.find_one(session, order_id)
+    if order.user_id != user.id:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=403, detail="Accès refusé")
+    return order

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -21,6 +21,13 @@ from .product import (
     ProductPage,
     StatusUpdate as ProductStatusUpdate,
 )
+from .orders import (
+    OrderBase,
+    OrderCreate,
+    OrderPage,
+    OrderStatusUpdate,
+    OrderItem,
+)
 
 __all__ = [
     "UserCreate",
@@ -42,4 +49,9 @@ __all__ = [
     "ProductUpdate",
     "ProductPage",
     "ProductStatusUpdate",
+    "OrderBase",
+    "OrderCreate",
+    "OrderPage",
+    "OrderStatusUpdate",
+    "OrderItem",
 ]

--- a/app/schemas/orders.py
+++ b/app/schemas/orders.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from app.models.order import OrderStatus
+
+class OrderItem(BaseModel):
+    product_id: UUID
+    quantity: int
+    price: float
+
+class OrderBase(BaseModel):
+    id: UUID
+    user_id: int
+    items: List[OrderItem]
+    total: float
+    status: OrderStatus
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+class OrderCreate(BaseModel):
+    items: List[OrderItem]
+
+class OrderPage(BaseModel):
+    orders: List[OrderBase]
+    total: int
+    page: int
+    limit: int
+
+class OrderStatusUpdate(BaseModel):
+    status: OrderStatus

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import auth, user_service, categories, products
+from . import auth, user_service, categories, products, orders
 
-__all__ = ["auth", "user_service", "categories", "products"]
+__all__ = ["auth", "user_service", "categories", "products", "orders"]

--- a/app/services/orders.py
+++ b/app/services/orders.py
@@ -1,0 +1,64 @@
+from typing import List, Optional, Tuple
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Order, OrderStatus
+from app.schemas.orders import OrderCreate, OrderItem
+
+async def create_order(
+    session: AsyncSession, user_id: int, data: OrderCreate
+) -> Order:
+    items = [item.dict() for item in data.items]
+    total = sum(item["price"] * item["quantity"] for item in items)
+    order = Order(user_id=user_id, items=items, total=total)
+    session.add(order)
+    await session.commit()
+    await session.refresh(order)
+    return order
+
+async def find_all_by_user(
+    session: AsyncSession,
+    user_id: int,
+    page: int,
+    limit: int,
+) -> Tuple[List[Order], int]:
+    query = select(Order).where(Order.user_id == user_id)
+    count = await session.scalar(select(func.count()).select_from(query.subquery()))
+    result = await session.execute(
+        query.order_by(Order.created_at.desc()).offset((page - 1) * limit).limit(limit)
+    )
+    return result.scalars().all(), count or 0
+
+async def find_all_admin(
+    session: AsyncSession,
+    page: int,
+    limit: int,
+    status: Optional[OrderStatus] = None,
+) -> Tuple[List[Order], int]:
+    query = select(Order)
+    if status:
+        query = query.where(Order.status == status.value)
+    count = await session.scalar(select(func.count()).select_from(query.subquery()))
+    result = await session.execute(
+        query.order_by(Order.created_at.desc()).offset((page - 1) * limit).limit(limit)
+    )
+    return result.scalars().all(), count or 0
+
+async def find_one(session: AsyncSession, order_id: UUID) -> Order:
+    result = await session.execute(select(Order).where(Order.id == order_id))
+    order = result.scalars().first()
+    if not order:
+        raise HTTPException(status_code=404, detail="Commande non trouvée.")
+    return order
+
+async def update_status(
+    session: AsyncSession, order_id: UUID, status: OrderStatus
+) -> Order:
+    order = await find_one(session, order_id)
+    order.status = status.value
+    await session.commit()
+    await session.refresh(order)
+    return order

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,72 @@
+import pytest
+from httpx import AsyncClient
+from uuid import UUID
+
+from app.main import app
+from app.db.session import engine, async_session
+from app.models import Base
+from app.services.auth import create_user, create_access_token
+
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.mark.asyncio
+async def test_orders_flow():
+    async with async_session() as session:
+        admin = await create_user(session, "admin_orders@test.com", "pass")
+        admin.role = "admin"
+        user = await create_user(session, "buyer@test.com", "pass")
+        await session.commit()
+        token_admin = create_access_token(str(admin.id))
+        token_user = create_access_token(str(user.id))
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        # unauthorized create
+        resp = await ac.post("/api/orders", json={"items": []})
+        assert resp.status_code == 401
+
+        headers_user = {"Authorization": f"Bearer {token_user}"}
+        headers_admin = {"Authorization": f"Bearer {token_admin}"}
+
+        # create order
+        resp = await ac.post(
+            "/api/orders",
+            json={"items": [{"product_id": str(UUID(int=1)), "quantity": 2, "price": 5.0}]},
+            headers=headers_user,
+        )
+        assert resp.status_code == 201
+        order_id = resp.json()["id"]
+        assert resp.json()["total"] == 10.0
+
+        # list user orders
+        resp = await ac.get("/api/orders", headers=headers_user)
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+        # get order
+        resp = await ac.get(f"/api/orders/{order_id}", headers=headers_user)
+        assert resp.status_code == 200
+
+        # admin list
+        resp = await ac.get("/api/admin/orders", headers=headers_admin)
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+        # admin update status
+        resp = await ac.put(
+            f"/api/admin/orders/{order_id}/status",
+            json={"status": "paid"},
+            headers=headers_admin,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "paid"
+
+        # forbidden access to other user's order
+        other_headers = {"Authorization": f"Bearer {token_admin}"}
+        resp = await ac.get(f"/api/orders/{order_id}", headers=other_headers)
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- model `Order` with enum status and JSONB items
- add Alembic migration for orders table
- implement service layer for order CRUD
- create user and admin routers
- expose order schemas
- add tests for order endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685ea579007c832c835e6bfb5a387a1f