### PR TITLE
Implement profile module with service and tests

### DIFF
--- a/app/routers/profile.py
+++ b/app/routers/profile.py
@@ -2,21 +2,24 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.schemas import ProfileOut, ProfileUpdate
-from app.services import user_service
+from app.schemas import ProfileOut, UpdateProfile
+from app.services import profile as profile_service
 from app.services.auth import get_current_user
 
 router = APIRouter()
 
 @router.get("/api/profile", response_model=ProfileOut)
-async def read_profile(user=Depends(get_current_user)):
-    return user
-
-@router.put("/api/profile", response_model=ProfileOut)
-async def update_profile(
-    data: ProfileUpdate,
+async def read_profile(
     session: AsyncSession = Depends(get_session),
     user=Depends(get_current_user),
 ):
-    updated = await user_service.update_profile(session, user.id, data.name, data.phone, data.avatar)
+    return await profile_service.get_profile(session, user.id)
+
+@router.put("/api/profile", response_model=ProfileOut)
+async def update_profile(
+    data: UpdateProfile,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+):
+    updated = await profile_service.update_profile(session, user.id, data)
     return updated

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -7,6 +7,7 @@ from .user import (
     ProfileOut,
     ProfileUpdate,
 )
+from .profile import UpdateProfile
 from .category import (
     CategoryBase,
     CategoryCreate,
@@ -39,6 +40,7 @@ __all__ = [
     "RoleUpdate",
     "ProfileOut",
     "ProfileUpdate",
+    "UpdateProfile",
     "CategoryBase",
     "CategoryCreate",
     "CategoryUpdate",

--- a/app/schemas/profile.py
+++ b/app/schemas/profile.py
@@ -1,0 +1,22 @@
+from typing import Optional
+from pydantic import BaseModel, HttpUrl, validator
+import re
+
+class UpdateProfile(BaseModel):
+    name: Optional[str] = None
+    phone: Optional[str] = None
+    avatar: Optional[HttpUrl] = None
+
+    @validator("name")
+    def validate_name(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("name must not be empty")
+        return v
+
+    @validator("phone")
+    def validate_phone(cls, v):
+        if v is not None:
+            pattern = r"^\+?[0-9]{7,15}$"
+            if not re.fullmatch(pattern, v):
+                raise ValueError("invalid phone number")
+        return v

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import auth, user_service, categories, products, orders
+from . import auth, user_service, categories, products, orders, profile
 
-__all__ = ["auth", "user_service", "categories", "products", "orders"]
+__all__ = ["auth", "user_service", "categories", "products", "orders", "profile"]

--- a/app/services/profile.py
+++ b/app/services/profile.py
@@ -1,0 +1,37 @@
+from typing import Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models import User
+from app.schemas.profile import UpdateProfile
+
+
+async def get_profile(session: AsyncSession, user_id: int) -> User:
+    result = await session.execute(select(User).where(User.id == user_id))
+    user = result.scalars().first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Utilisateur non trouvé.")
+    return user
+
+
+async def update_profile(
+    session: AsyncSession, user_id: int, data: UpdateProfile
+) -> User:
+    result = await session.execute(select(User).where(User.id == user_id))
+    user = result.scalars().first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Utilisateur non trouvé.")
+
+    if data.name is not None:
+        user.name = data.name
+    if data.phone is not None:
+        user.phone = data.phone
+    if data.avatar is not None:
+        user.avatar = str(data.avatar)
+
+    await session.commit()
+    await session.refresh(user)
+    return user

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,50 @@
+import pytest
+from httpx import AsyncClient
+
+from app.main import app
+from app.db.session import engine, async_session
+from app.models import Base
+from app.services.auth import create_user, create_access_token
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.mark.asyncio
+async def test_profile_endpoints():
+    async with async_session() as session:
+        user = await create_user(session, "profile@test.com", "pass")
+        await session.commit()
+        token = create_access_token(str(user.id))
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        # unauthorized access
+        resp = await ac.get("/api/profile")
+        assert resp.status_code == 401
+
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = await ac.get("/api/profile", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["email"] == "profile@test.com"
+
+        resp = await ac.put(
+            "/api/profile",
+            json={"name": "Tester", "phone": "+33123456789"},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Tester"
+        assert resp.json()["phone"] == "+33123456789"
+
+        resp = await ac.put(
+            "/api/profile",
+            json={"phone": "bad-number"},
+            headers=headers,
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- add `UpdateProfile` schema with validation rules
- create profile service for reading and updating user profile
- wire profile router to the new service
- expose new schema and service via package `__init__`
- test profile endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685eaa934008832c9b19a78c8b215ee8