### PR TITLE
Add search module with full text

### DIFF
--- a/alembic/versions/0005_create_services_and_search_indexes.py
+++ b/alembic/versions/0005_create_services_and_search_indexes.py
@@ -1,0 +1,38 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0005'
+down_revision = '0004'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'services',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_index(
+        'product_search_idx',
+        'products',
+        [sa.text("to_tsvector('french', name || ' ' || coalesce(description,''))")],
+        postgresql_using='gin'
+    )
+    op.create_index(
+        'service_search_idx',
+        'services',
+        [sa.text("to_tsvector('french', name || ' ' || coalesce(description,''))")],
+        postgresql_using='gin'
+    )
+
+
+def downgrade():
+    op.drop_index('service_search_idx', table_name='services')
+    op.drop_index('product_search_idx', table_name='products')
+    op.drop_table('services')
+

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,5 +2,6 @@ from .user import User, Base
 from .category import Category
 from .product import Product
 from .order import Order
+from .service import Service
 
-__all__ = ["User", "Base", "Category", "Product", "Order"]
+__all__ = ["User", "Base", "Category", "Product", "Order", "Service"]

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -1,0 +1,16 @@
+import uuid
+from sqlalchemy import Column, String, Text, DateTime
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from .user import Base
+
+class Service(Base):
+    __tablename__ = "services"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from . import auth, profile, categories, products, orders
+from . import auth, profile, categories, products, orders, search
 from .professional import products as professional_products
 from .admin import (
     users as admin_users,
@@ -15,6 +15,7 @@ api_router.include_router(profile.router, tags=["profile"])
 api_router.include_router(categories.router, tags=["categories"])
 api_router.include_router(products.router, tags=["products"])
 api_router.include_router(orders.router, tags=["orders"])
+api_router.include_router(search.router, tags=["search"])
 api_router.include_router(admin_users.router, tags=["admin"])
 api_router.include_router(admin_categories.router, tags=["admin"])
 api_router.include_router(admin_products.router, tags=["admin"])
@@ -27,6 +28,7 @@ __all__ = [
     "categories",
     "products",
     "orders",
+    "search",
     "admin_users",
     "admin_categories",
     "admin_products",

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -1,0 +1,25 @@
+from typing import Literal
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import SearchParams
+from app.services import search_service
+
+router = APIRouter()
+
+@router.get("/api/search")
+async def search(params: SearchParams = Depends(), session: AsyncSession = Depends(get_session)):
+    try:
+        return await search_service.search(
+            session,
+            query=params.q,
+            search_type=params.type or "all",
+            page=params.page or 1,
+            limit=params.limit or 10,
+        )
+    except HTTPException as e:
+        raise e
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal server error")
+

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -29,6 +29,7 @@ from .orders import (
     OrderStatusUpdate,
     OrderItem,
 )
+from .search import SearchParams
 
 __all__ = [
     "UserCreate",
@@ -56,4 +57,5 @@ __all__ = [
     "OrderPage",
     "OrderStatusUpdate",
     "OrderItem",
+    "SearchParams",
 ]

--- a/app/schemas/search.py
+++ b/app/schemas/search.py
@@ -1,0 +1,9 @@
+from typing import Optional, Literal
+from pydantic import BaseModel, constr
+
+class SearchParams(BaseModel):
+    q: constr(min_length=1)
+    type: Optional[Literal["products", "services", "all"]] = "all"
+    page: Optional[int] = 1
+    limit: Optional[int] = 10
+

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,11 @@
-from . import auth, user_service, categories, products, orders, profile
+from . import auth, user_service, categories, products, orders, profile, search_service
 
-__all__ = ["auth", "user_service", "categories", "products", "orders", "profile"]
+__all__ = [
+    "auth",
+    "user_service",
+    "categories",
+    "products",
+    "orders",
+    "profile",
+    "search_service",
+]

--- a/app/services/search_service.py
+++ b/app/services/search_service.py
@@ -1,0 +1,54 @@
+from typing import Literal, Optional, List, Dict
+
+from fastapi import HTTPException
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Product, Service
+
+async def search(
+    session: AsyncSession,
+    query: str,
+    search_type: Literal["products", "services", "all"] = "all",
+    page: int = 1,
+    limit: int = 10,
+) -> Dict:
+    q = (query or "").strip()
+    if not q:
+        raise HTTPException(status_code=400, detail="Query must not be empty")
+
+    ts_query = func.plainto_tsquery('french', q)
+    products: List[Product] = []
+    services: List[Service] = []
+    total = 0
+
+    if search_type in ("products", "all"):
+        p_base = select(Product).where(
+            func.to_tsvector('french', Product.name + ' ' + func.coalesce(Product.description, '')).op('@@')(ts_query)
+        )
+        count_query = select(func.count()).select_from(p_base.subquery())
+        total_p = await session.scalar(count_query)
+        result = await session.execute(
+            p_base.order_by(Product.created_at.desc()).offset((page - 1) * limit).limit(limit)
+        )
+        products = result.scalars().all()
+        total += total_p or 0
+
+    if search_type in ("services", "all"):
+        s_base = select(Service).where(
+            func.to_tsvector('french', Service.name + ' ' + func.coalesce(Service.description, '')).op('@@')(ts_query)
+        )
+        count_query = select(func.count()).select_from(s_base.subquery())
+        total_s = await session.scalar(count_query)
+        result = await session.execute(
+            s_base.order_by(Service.created_at.desc()).offset((page - 1) * limit).limit(limit)
+        )
+        services = result.scalars().all()
+        total += total_s or 0
+
+    return {
+        "products": products if search_type in ("products", "all") else [],
+        "services": services if search_type in ("services", "all") else [],
+        "pagination": {"total": total, "page": page, "limit": limit},
+    }
+

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,48 @@
+import pytest
+from httpx import AsyncClient
+
+from app.main import app
+from app.db.session import engine, async_session
+from app.models import Base, Product, Service
+from app.services.auth import create_user
+
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.mark.asyncio
+async def test_search_endpoints(monkeypatch):
+    async with async_session() as session:
+        user = await create_user(session, "search@test.com", "pass")
+        prod = Product(name="Test Phone", price=10, stock=5, user_id=user.id)
+        serv = Service(name="Phone Repair", description="Fix phones")
+        session.add_all([prod, serv])
+        await session.commit()
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get("/api/search", params={"q": "Phone"})
+        assert resp.status_code == 200
+        assert resp.json()["pagination"]["total"] >= 2
+
+        resp = await ac.get("/api/search")
+        assert resp.status_code == 422
+
+        resp = await ac.get("/api/search", params={"q": "Phone", "type": "products"})
+        assert resp.status_code == 200
+        assert resp.json()["services"] == []
+
+        resp = await ac.get("/api/search", params={"q": "Phone", "limit": 1, "page": 1})
+        assert resp.status_code == 200
+        assert resp.json()["pagination"]["limit"] == 1
+
+        async def raise_error(*args, **kwargs):
+            raise Exception("boom")
+
+        monkeypatch.setattr("app.services.search_service.search", raise_error)
+        resp = await ac.get("/api/search", params={"q": "Phone"})
+        assert resp.status_code == 500
+


### PR DESCRIPTION
## Summary
- add `Service` model and Alembic migration for service table and search indexes
- implement `search_service` with Postgres full-text search
- expose new `/api/search` route
- add Pydantic schema for search params
- wire new router and service
- provide tests for search functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685ead18af18832cb625179c338e3d06