### PR TITLE
Add new admin features

### DIFF
--- a/alembic/versions/0006_create_hero_slides.py
+++ b/alembic/versions/0006_create_hero_slides.py
@@ -1,0 +1,24 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0006'
+down_revision = '0005'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'hero_slides',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('image_url', sa.String(), nullable=False),
+        sa.Column('link_url', sa.String(), nullable=True),
+        sa.Column('order', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+def downgrade():
+    op.drop_table('hero_slides')

--- a/alembic/versions/0007_create_promotions.py
+++ b/alembic/versions/0007_create_promotions.py
@@ -1,0 +1,26 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0007'
+down_revision = '0006'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'promotions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('discount_type', sa.String(), nullable=False),
+        sa.Column('value', sa.Float(), nullable=False),
+        sa.Column('start_date', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('end_date', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('active', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+def downgrade():
+    op.drop_table('promotions')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,5 +3,16 @@ from .category import Category
 from .product import Product
 from .order import Order
 from .service import Service
+from .hero_slide import HeroSlide
+from .promotion import Promotion
 
-__all__ = ["User", "Base", "Category", "Product", "Order", "Service"]
+__all__ = [
+    "User",
+    "Base",
+    "Category",
+    "Product",
+    "Order",
+    "Service",
+    "HeroSlide",
+    "Promotion",
+]

--- a/app/models/hero_slide.py
+++ b/app/models/hero_slide.py
@@ -1,0 +1,18 @@
+import uuid
+from sqlalchemy import Column, String, Integer, Boolean, DateTime
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from .user import Base
+
+class HeroSlide(Base):
+    __tablename__ = "hero_slides"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    title = Column(String, nullable=False)
+    image_url = Column(String, nullable=False)
+    link_url = Column(String, nullable=True)
+    order = Column(Integer, nullable=False, default=0)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/app/models/promotion.py
+++ b/app/models/promotion.py
@@ -1,0 +1,20 @@
+import uuid
+from sqlalchemy import Column, String, Text, Float, DateTime, Boolean
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from .user import Base
+
+class Promotion(Base):
+    __tablename__ = "promotions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    discount_type = Column(String, nullable=False)
+    value = Column(Float, nullable=False)
+    start_date = Column(DateTime(timezone=True), nullable=False)
+    end_date = Column(DateTime(timezone=True), nullable=False)
+    active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -7,6 +7,9 @@ from .admin import (
     categories as admin_categories,
     products as admin_products,
     orders as admin_orders,
+    hero_slides as admin_hero_slides,
+    promotions as admin_promotions,
+    dashboard as admin_dashboard,
 )
 
 api_router = APIRouter()
@@ -20,6 +23,9 @@ api_router.include_router(admin_users.router, tags=["admin"])
 api_router.include_router(admin_categories.router, tags=["admin"])
 api_router.include_router(admin_products.router, tags=["admin"])
 api_router.include_router(admin_orders.router, tags=["admin"])
+api_router.include_router(admin_hero_slides.router, tags=["admin"])
+api_router.include_router(admin_promotions.router, tags=["admin"])
+api_router.include_router(admin_dashboard.router, tags=["admin"])
 api_router.include_router(professional_products.router, tags=["professional"])
 __all__ = [
     "api_router",
@@ -33,5 +39,8 @@ __all__ = [
     "admin_categories",
     "admin_products",
     "admin_orders",
+    "admin_hero_slides",
+    "admin_promotions",
+    "admin_dashboard",
     "professional_products",
 ]

--- a/app/routers/admin/__init__.py
+++ b/app/routers/admin/__init__.py
@@ -1,3 +1,19 @@
-from . import users, categories, products, orders
+from . import (
+    users,
+    categories,
+    products,
+    orders,
+    hero_slides,
+    promotions,
+    dashboard,
+)
 
-__all__ = ["users", "categories", "products", "orders"]
+__all__ = [
+    "users",
+    "categories",
+    "products",
+    "orders",
+    "hero_slides",
+    "promotions",
+    "dashboard",
+]

--- a/app/routers/admin/categories.py
+++ b/app/routers/admin/categories.py
@@ -1,13 +1,36 @@
 from uuid import UUID
+from typing import Optional
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.schemas import CategoryBase, CategoryCreate, CategoryUpdate
+from app.schemas import CategoryBase, CategoryCreate, CategoryUpdate, CategoryPage
 from app.services import categories as category_service
 from app.core.dependencies import require_role
 
 router = APIRouter()
+
+@router.get("/api/admin/categories", response_model=CategoryPage)
+async def list_categories_admin(
+    page: int = 1,
+    limit: int = 10,
+    name: Optional[str] = None,
+    include_inactive: bool = False,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    categories, total = await category_service.find_all(session, page, limit, name)
+    if not include_inactive:
+        categories = [c for c in categories if getattr(c, "is_active", True)]
+    return {"categories": categories, "total": total, "page": page, "limit": limit}
+
+@router.get("/api/admin/categories/{category_id}", response_model=CategoryBase)
+async def get_category_admin(
+    category_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await category_service.find_one(session, category_id)
 
 @router.post("/api/admin/categories", response_model=CategoryBase, status_code=status.HTTP_201_CREATED)
 async def create_category(

--- a/app/routers/admin/dashboard.py
+++ b/app/routers/admin/dashboard.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.core.dependencies import require_role
+from app.services import dashboard as dashboard_service
+
+router = APIRouter()
+
+@router.get("/api/admin/dashboard")
+async def get_dashboard(
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await dashboard_service.get_stats(session)

--- a/app/routers/admin/hero_slides.py
+++ b/app/routers/admin/hero_slides.py
@@ -1,0 +1,61 @@
+from uuid import UUID
+from typing import Optional
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import (
+    HeroSlideBase,
+    HeroSlideCreate,
+    HeroSlideUpdate,
+    HeroSlidePage,
+)
+from app.services import hero_slides as service
+from app.core.dependencies import require_role
+
+router = APIRouter()
+
+@router.get("/api/admin/hero-slides", response_model=HeroSlidePage)
+async def list_slides(
+    page: int = 1,
+    limit: int = 10,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    slides, total = await service.find_all(session, page, limit)
+    return {"slides": slides, "total": total, "page": page, "limit": limit}
+
+@router.get("/api/admin/hero-slides/{slide_id}", response_model=HeroSlideBase)
+async def get_slide(
+    slide_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await service.find_one(session, slide_id)
+
+@router.post("/api/admin/hero-slides", response_model=HeroSlideBase, status_code=status.HTTP_201_CREATED)
+async def create_slide(
+    data: HeroSlideCreate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await service.create(session, data)
+
+@router.put("/api/admin/hero-slides/{slide_id}", response_model=HeroSlideBase)
+async def update_slide(
+    slide_id: UUID,
+    data: HeroSlideUpdate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await service.update(session, slide_id, data)
+
+@router.delete("/api/admin/hero-slides/{slide_id}")
+async def delete_slide(
+    slide_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    await service.remove(session, slide_id)
+    return {"message": "Slide supprimé"}

--- a/app/routers/admin/promotions.py
+++ b/app/routers/admin/promotions.py
@@ -1,0 +1,59 @@
+from uuid import UUID
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.schemas import (
+    PromotionBase,
+    PromotionCreate,
+    PromotionUpdate,
+    PromotionPage,
+)
+from app.services import promotions as service
+from app.core.dependencies import require_role
+
+router = APIRouter()
+
+@router.get("/api/admin/promotions", response_model=PromotionPage)
+async def list_promotions(
+    page: int = 1,
+    limit: int = 10,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    promos, total = await service.find_all(session, page, limit)
+    return {"promotions": promos, "total": total, "page": page, "limit": limit}
+
+@router.get("/api/admin/promotions/{promo_id}", response_model=PromotionBase)
+async def get_promo(
+    promo_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await service.find_one(session, promo_id)
+
+@router.post("/api/admin/promotions", response_model=PromotionBase, status_code=status.HTTP_201_CREATED)
+async def create_promo(
+    data: PromotionCreate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await service.create(session, data)
+
+@router.put("/api/admin/promotions/{promo_id}", response_model=PromotionBase)
+async def update_promo(
+    promo_id: UUID,
+    data: PromotionUpdate,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    return await service.update(session, promo_id, data)
+
+@router.delete("/api/admin/promotions/{promo_id}")
+async def delete_promo(
+    promo_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    admin=Depends(require_role("admin")),
+):
+    await service.remove(session, promo_id)
+    return {"message": "Promotion supprimée"}

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -30,6 +30,8 @@ from .orders import (
     OrderItem,
 )
 from .search import SearchParams
+from .hero_slide import HeroSlideBase, HeroSlideCreate, HeroSlideUpdate, HeroSlidePage
+from .promotion import PromotionBase, PromotionCreate, PromotionUpdate, PromotionPage
 
 __all__ = [
     "UserCreate",
@@ -58,4 +60,12 @@ __all__ = [
     "OrderStatusUpdate",
     "OrderItem",
     "SearchParams",
+    "HeroSlideBase",
+    "HeroSlideCreate",
+    "HeroSlideUpdate",
+    "HeroSlidePage",
+    "PromotionBase",
+    "PromotionCreate",
+    "PromotionUpdate",
+    "PromotionPage",
 ]

--- a/app/schemas/hero_slide.py
+++ b/app/schemas/hero_slide.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from uuid import UUID
+from typing import List
+
+from pydantic import BaseModel
+
+class HeroSlideBase(BaseModel):
+    id: UUID
+    title: str
+    image_url: str
+    link_url: str | None = None
+    order: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+class HeroSlideCreate(BaseModel):
+    title: str
+    image_url: str
+    link_url: str | None = None
+    order: int = 0
+    is_active: bool = True
+
+class HeroSlideUpdate(BaseModel):
+    title: str | None = None
+    image_url: str | None = None
+    link_url: str | None = None
+    order: int | None = None
+    is_active: bool | None = None
+
+class HeroSlidePage(BaseModel):
+    slides: List[HeroSlideBase]
+    total: int
+    page: int
+    limit: int

--- a/app/schemas/promotion.py
+++ b/app/schemas/promotion.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from uuid import UUID
+from typing import List
+
+from pydantic import BaseModel
+
+class PromotionBase(BaseModel):
+    id: UUID
+    name: str
+    description: str | None = None
+    discount_type: str
+    value: float
+    start_date: datetime
+    end_date: datetime
+    active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+class PromotionCreate(BaseModel):
+    name: str
+    description: str | None = None
+    discount_type: str
+    value: float
+    start_date: datetime
+    end_date: datetime
+    active: bool = True
+
+class PromotionUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    discount_type: str | None = None
+    value: float | None = None
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    active: bool | None = None
+
+class PromotionPage(BaseModel):
+    promotions: List[PromotionBase]
+    total: int
+    page: int
+    limit: int

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,4 +1,15 @@
-from . import auth, user_service, categories, products, orders, profile, search_service
+from . import (
+    auth,
+    user_service,
+    categories,
+    products,
+    orders,
+    profile,
+    search_service,
+    hero_slides,
+    promotions,
+    dashboard,
+)
 
 __all__ = [
     "auth",
@@ -8,4 +19,7 @@ __all__ = [
     "orders",
     "profile",
     "search_service",
+    "hero_slides",
+    "promotions",
+    "dashboard",
 ]

--- a/app/services/dashboard.py
+++ b/app/services/dashboard.py
@@ -1,0 +1,22 @@
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import User, Order, Product
+
+async def get_stats(session: AsyncSession) -> dict:
+    total_users = await session.scalar(select(func.count()).select_from(User))
+    total_orders = await session.scalar(select(func.count()).select_from(Order))
+    total_revenue = await session.scalar(select(func.sum(Order.total))) or 0
+    active_products = await session.scalar(
+        select(func.count()).select_from(Product).where(Product.status == 'active')
+    )
+    pending_requests = await session.scalar(
+        select(func.count()).select_from(Product).where(Product.status == 'pending')
+    )
+    return {
+        'total_users': total_users or 0,
+        'total_orders': total_orders or 0,
+        'total_revenue': float(total_revenue or 0),
+        'active_products': active_products or 0,
+        'pending_requests': pending_requests or 0,
+    }

--- a/app/services/hero_slides.py
+++ b/app/services/hero_slides.py
@@ -1,0 +1,43 @@
+from typing import List, Tuple
+from uuid import UUID
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import HTTPException
+
+from app.models import HeroSlide
+
+async def find_all(session: AsyncSession, page: int, limit: int) -> Tuple[List[HeroSlide], int]:
+    query = select(HeroSlide)
+    count = await session.scalar(select(func.count()).select_from(query.subquery()))
+    result = await session.execute(
+        query.order_by(HeroSlide.order).offset((page - 1) * limit).limit(limit)
+    )
+    return result.scalars().all(), count or 0
+
+async def find_one(session: AsyncSession, slide_id: UUID) -> HeroSlide:
+    result = await session.execute(select(HeroSlide).where(HeroSlide.id == slide_id))
+    slide = result.scalars().first()
+    if not slide:
+        raise HTTPException(status_code=404, detail="Slide non trouvé.")
+    return slide
+
+async def create(session: AsyncSession, data) -> HeroSlide:
+    slide = HeroSlide(**data.dict())
+    session.add(slide)
+    await session.commit()
+    await session.refresh(slide)
+    return slide
+
+async def update(session: AsyncSession, slide_id: UUID, data) -> HeroSlide:
+    slide = await find_one(session, slide_id)
+    for k, v in data.dict(exclude_unset=True).items():
+        setattr(slide, k, v)
+    await session.commit()
+    await session.refresh(slide)
+    return slide
+
+async def remove(session: AsyncSession, slide_id: UUID) -> None:
+    slide = await find_one(session, slide_id)
+    await session.delete(slide)
+    await session.commit()

--- a/app/services/promotions.py
+++ b/app/services/promotions.py
@@ -1,0 +1,43 @@
+from typing import List, Tuple
+from uuid import UUID
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import HTTPException
+
+from app.models import Promotion
+
+async def find_all(session: AsyncSession, page: int, limit: int) -> Tuple[List[Promotion], int]:
+    query = select(Promotion)
+    count = await session.scalar(select(func.count()).select_from(query.subquery()))
+    result = await session.execute(
+        query.order_by(Promotion.created_at.desc()).offset((page - 1) * limit).limit(limit)
+    )
+    return result.scalars().all(), count or 0
+
+async def find_one(session: AsyncSession, promotion_id: UUID) -> Promotion:
+    result = await session.execute(select(Promotion).where(Promotion.id == promotion_id))
+    promo = result.scalars().first()
+    if not promo:
+        raise HTTPException(status_code=404, detail="Promotion non trouvée.")
+    return promo
+
+async def create(session: AsyncSession, data) -> Promotion:
+    promo = Promotion(**data.dict())
+    session.add(promo)
+    await session.commit()
+    await session.refresh(promo)
+    return promo
+
+async def update(session: AsyncSession, promotion_id: UUID, data) -> Promotion:
+    promo = await find_one(session, promotion_id)
+    for k, v in data.dict(exclude_unset=True).items():
+        setattr(promo, k, v)
+    await session.commit()
+    await session.refresh(promo)
+    return promo
+
+async def remove(session: AsyncSession, promotion_id: UUID) -> None:
+    promo = await find_one(session, promotion_id)
+    await session.delete(promo)
+    await session.commit()

--- a/tests/test_admin_new.py
+++ b/tests/test_admin_new.py
@@ -1,0 +1,110 @@
+import pytest
+from httpx import AsyncClient
+from datetime import datetime, timedelta
+
+from app.main import app
+from app.db.session import engine, async_session
+from app.models import Base
+from app.services.auth import create_user, create_access_token
+
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.mark.asyncio
+async def test_admin_hero_slides_and_promotions_and_dashboard():
+    async with async_session() as session:
+        admin = await create_user(session, "admin@test.com", "pass")
+        admin.role = "admin"
+        user = await create_user(session, "user@test.com", "pass")
+        await session.commit()
+        token_admin = create_access_token(str(admin.id))
+        token_user = create_access_token(str(user.id))
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        headers_admin = {"Authorization": f"Bearer {token_admin}"}
+        headers_user = {"Authorization": f"Bearer {token_user}"}
+
+        # unauthorized hero slide create
+        resp = await ac.post("/api/admin/hero-slides", json={"title": "t", "image_url": "i"})
+        assert resp.status_code == 401
+        resp = await ac.post(
+            "/api/admin/hero-slides",
+            json={"title": "t", "image_url": "i"},
+            headers=headers_user,
+        )
+        assert resp.status_code == 403
+
+        # create hero slide
+        resp = await ac.post(
+            "/api/admin/hero-slides",
+            json={"title": "Slide", "image_url": "img", "order": 1},
+            headers=headers_admin,
+        )
+        assert resp.status_code == 201
+        slide_id = resp.json()["id"]
+
+        # list
+        resp = await ac.get("/api/admin/hero-slides", headers=headers_admin)
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+        # get
+        resp = await ac.get(f"/api/admin/hero-slides/{slide_id}", headers=headers_admin)
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Slide"
+
+        # update
+        resp = await ac.put(
+            f"/api/admin/hero-slides/{slide_id}",
+            json={"title": "New"},
+            headers=headers_admin,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "New"
+
+        # delete
+        resp = await ac.delete(f"/api/admin/hero-slides/{slide_id}", headers=headers_admin)
+        assert resp.status_code == 200
+        resp = await ac.get(f"/api/admin/hero-slides/{slide_id}", headers=headers_admin)
+        assert resp.status_code == 404
+
+        # promotions
+        promo_data = {
+            "name": "Promo",
+            "discount_type": "percent",
+            "value": 10,
+            "start_date": datetime.utcnow().isoformat(),
+            "end_date": (datetime.utcnow() + timedelta(days=1)).isoformat(),
+        }
+        resp = await ac.post("/api/admin/promotions", json=promo_data, headers=headers_admin)
+        assert resp.status_code == 201
+        promo_id = resp.json()["id"]
+
+        resp = await ac.get("/api/admin/promotions", headers=headers_admin)
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+        resp = await ac.get(f"/api/admin/promotions/{promo_id}", headers=headers_admin)
+        assert resp.status_code == 200
+
+        resp = await ac.put(
+            f"/api/admin/promotions/{promo_id}",
+            json={"active": False},
+            headers=headers_admin,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["active"] is False
+
+        resp = await ac.delete(f"/api/admin/promotions/{promo_id}", headers=headers_admin)
+        assert resp.status_code == 200
+
+        # dashboard
+        resp = await ac.get("/api/admin/dashboard", headers=headers_admin)
+        assert resp.status_code == 200
+        assert "total_users" in resp.json()
+


### PR DESCRIPTION
## Summary
- add new hero slide and promotion models with Alembic migrations
- implement services and routers for hero slides and promotions
- add admin dashboard endpoint with aggregated stats
- extend admin categories with list/get endpoints
- update API router and admin package to include new modules
- provide tests for admin hero slides, promotions and dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6863d072c32c832c90f845c4ae153828