### PR TITLE
Add promotions module with schema and tests

### DIFF
--- a/alembic/versions/0008_update_promotions.py
+++ b/alembic/versions/0008_update_promotions.py
@@ -1,0 +1,31 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0008'
+down_revision = '0007'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table('promotions')
+    op.create_table(
+        'promotions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('discount_type', sa.String(), nullable=False),
+        sa.Column('discount_value', sa.Float(), nullable=False),
+        sa.Column('start_date', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('end_date', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('conditions', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('usage_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table('promotions')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,7 +4,7 @@ from .product import Product
 from .order import Order
 from .service import Service
 from .hero_slide import HeroSlide
-from .promotion import Promotion
+from .promotion import Promotion, PromotionDiscountType
 
 __all__ = [
     "User",
@@ -15,4 +15,5 @@ __all__ = [
     "Service",
     "HeroSlide",
     "Promotion",
+    "PromotionDiscountType",
 ]

--- a/app/models/promotion.py
+++ b/app/models/promotion.py
@@ -1,9 +1,15 @@
 import uuid
-from sqlalchemy import Column, String, Text, Float, DateTime, Boolean
-from sqlalchemy.dialects.postgresql import UUID
+from enum import Enum
+from sqlalchemy import Column, String, Text, Float, DateTime, Boolean, Integer
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.sql import func
 
 from .user import Base
+
+
+class PromotionDiscountType(str, Enum):
+    percentage = "percentage"
+    fixed = "fixed"
 
 class Promotion(Base):
     __tablename__ = "promotions"
@@ -11,10 +17,12 @@ class Promotion(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String, nullable=False)
     description = Column(Text, nullable=True)
-    discount_type = Column(String, nullable=False)
-    value = Column(Float, nullable=False)
+    discount_type = Column(String, nullable=False, default=PromotionDiscountType.percentage.value)
+    discount_value = Column(Float, nullable=False)
     start_date = Column(DateTime(timezone=True), nullable=False)
     end_date = Column(DateTime(timezone=True), nullable=False)
-    active = Column(Boolean, nullable=False, default=True)
+    conditions = Column(JSONB, nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    usage_count = Column(Integer, nullable=False, default=0)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/app/routers/admin/promotions.py
+++ b/app/routers/admin/promotions.py
@@ -49,11 +49,11 @@ async def update_promo(
 ):
     return await service.update(session, promo_id, data)
 
-@router.delete("/api/admin/promotions/{promo_id}")
+@router.delete("/api/admin/promotions/{promo_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_promo(
     promo_id: UUID,
     session: AsyncSession = Depends(get_session),
     admin=Depends(require_role("admin")),
 ):
     await service.remove(session, promo_id)
-    return {"message": "Promotion supprimée"}
+    return None

--- a/app/schemas/promotion.py
+++ b/app/schemas/promotion.py
@@ -1,18 +1,28 @@
 from datetime import datetime
 from uuid import UUID
-from typing import List
+from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, constr, confloat
+
+from app.models.promotion import PromotionDiscountType
+
+
+class PromotionConditions(BaseModel):
+    minAmount: Optional[float] = None
+    categories: Optional[List[str]] = None
+    maxUsage: Optional[int] = None
 
 class PromotionBase(BaseModel):
     id: UUID
     name: str
-    description: str | None = None
-    discount_type: str
-    value: float
+    description: Optional[str] = None
+    discount_type: PromotionDiscountType
+    discount_value: float
     start_date: datetime
     end_date: datetime
-    active: bool
+    conditions: Optional[PromotionConditions] = None
+    is_active: bool
+    usage_count: int
     created_at: datetime
     updated_at: datetime
 
@@ -20,22 +30,24 @@ class PromotionBase(BaseModel):
         orm_mode = True
 
 class PromotionCreate(BaseModel):
-    name: str
-    description: str | None = None
-    discount_type: str
-    value: float
+    name: constr(min_length=1)
+    description: Optional[str] = None
+    discount_type: PromotionDiscountType
+    discount_value: confloat(gt=0)
     start_date: datetime
     end_date: datetime
-    active: bool = True
+    conditions: Optional[PromotionConditions] = None
+    is_active: bool
 
 class PromotionUpdate(BaseModel):
-    name: str | None = None
-    description: str | None = None
-    discount_type: str | None = None
-    value: float | None = None
-    start_date: datetime | None = None
-    end_date: datetime | None = None
-    active: bool | None = None
+    name: Optional[constr(min_length=1)] = None
+    description: Optional[str] = None
+    discount_type: Optional[PromotionDiscountType] = None
+    discount_value: Optional[confloat(gt=0)] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    conditions: Optional[PromotionConditions] = None
+    is_active: Optional[bool] = None
 
 class PromotionPage(BaseModel):
     promotions: List[PromotionBase]

--- a/tests/test_admin_new.py
+++ b/tests/test_admin_new.py
@@ -76,10 +76,11 @@ async def test_admin_hero_slides_and_promotions_and_dashboard():
         # promotions
         promo_data = {
             "name": "Promo",
-            "discount_type": "percent",
-            "value": 10,
+            "discount_type": "percentage",
+            "discount_value": 10,
             "start_date": datetime.utcnow().isoformat(),
             "end_date": (datetime.utcnow() + timedelta(days=1)).isoformat(),
+            "is_active": True,
         }
         resp = await ac.post("/api/admin/promotions", json=promo_data, headers=headers_admin)
         assert resp.status_code == 201
@@ -94,14 +95,14 @@ async def test_admin_hero_slides_and_promotions_and_dashboard():
 
         resp = await ac.put(
             f"/api/admin/promotions/{promo_id}",
-            json={"active": False},
+            json={"is_active": False},
             headers=headers_admin,
         )
         assert resp.status_code == 200
-        assert resp.json()["active"] is False
+        assert resp.json()["is_active"] is False
 
         resp = await ac.delete(f"/api/admin/promotions/{promo_id}", headers=headers_admin)
-        assert resp.status_code == 200
+        assert resp.status_code == 204
 
         # dashboard
         resp = await ac.get("/api/admin/dashboard", headers=headers_admin)

--- a/tests/test_promotions.py
+++ b/tests/test_promotions.py
@@ -1,0 +1,85 @@
+import pytest
+from httpx import AsyncClient
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from app.main import app
+from app.db.session import engine, async_session
+from app.models import Base
+from app.services.auth import create_user, create_access_token
+
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.mark.asyncio
+async def test_promotions_errors_and_crud():
+    async with async_session() as session:
+        admin = await create_user(session, "adminp@test.com", "pass")
+        admin.role = "admin"
+        user = await create_user(session, "userp@test.com", "pass")
+        await session.commit()
+        token_admin = create_access_token(str(admin.id))
+        token_user = create_access_token(str(user.id))
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        valid_data = {
+            "name": "Promo",
+            "discount_type": "percentage",
+            "discount_value": 5,
+            "start_date": datetime.utcnow().isoformat(),
+            "end_date": (datetime.utcnow() + timedelta(days=1)).isoformat(),
+            "is_active": True,
+        }
+
+        # unauthorized
+        resp = await ac.post("/api/admin/promotions", json=valid_data)
+        assert resp.status_code == 401
+
+        # forbidden
+        resp = await ac.post(
+            "/api/admin/promotions",
+            json=valid_data,
+            headers={"Authorization": f"Bearer {token_user}"},
+        )
+        assert resp.status_code == 403
+
+        # invalid dates
+        bad = valid_data.copy()
+        bad["start_date"], bad["end_date"] = bad["end_date"], bad["start_date"]
+        resp = await ac.post(
+            "/api/admin/promotions",
+            json=bad,
+            headers={"Authorization": f"Bearer {token_admin}"},
+        )
+        assert resp.status_code == 400
+
+        # create
+        resp = await ac.post(
+            "/api/admin/promotions",
+            json=valid_data,
+            headers={"Authorization": f"Bearer {token_admin}"},
+        )
+        assert resp.status_code == 201
+        promo_id = resp.json()["id"]
+
+        # not found
+        resp = await ac.get(
+            f"/api/admin/promotions/{uuid4()}",
+            headers={"Authorization": f"Bearer {token_admin}"},
+        )
+        assert resp.status_code == 404
+
+        # list and detail
+        resp = await ac.get("/api/admin/promotions", headers={"Authorization": f"Bearer {token_admin}"})
+        assert resp.status_code == 200
+        resp = await ac.get(f"/api/admin/promotions/{promo_id}", headers={"Authorization": f"Bearer {token_admin}"})
+        assert resp.status_code == 200
+
+        # unauthorized delete
+        resp = await ac.delete(f"/api/admin/promotions/{promo_id}")
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- extend promotions model with new fields and enum
- update pydantic schemas
- add validation and 204 delete response
- include alembic migration
- add tests for promotions CRUD and permissions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6863d22eaa6c832cb4b4c7ad3d2cd0b8