### PR TITLE
Fix pydantic BaseSettings import

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@db:5432/postgres"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn[standard]
 python-dotenv
 pydantic
+pydantic-settings
 sqlalchemy>=1.4
 asyncpg
 bcrypt


### PR DESCRIPTION
## Summary
- use BaseSettings from pydantic-settings
- include pydantic-settings in requirements

## Testing
- `pytest -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6863e30172e8832c9b34a7f47d9b2bfd