### PR TITLE
Fix library issue with fastapi_jwt_auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 fastapi
 uvicorn[standard]
 python-dotenv
-pydantic
-pydantic-settings
+pydantic[email]<2
+pydantic-settings<2
 sqlalchemy>=1.4
 asyncpg
 bcrypt
@@ -10,4 +10,3 @@ PyJWT
 pytest
 httpx
 fastapi-jwt-auth
-pydantic[email]


### PR DESCRIPTION
## Summary
- pin pydantic below version 2 in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6863e61f2fcc832cb17732d0db4d20b8