### PR TITLE
Fix requirements for email validation and pydantic compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 python-dotenv
-pydantic==2.10.6
+pydantic[email]==1.10.13
 sqlalchemy>=1.4
 asyncpg
 bcrypt
@@ -10,3 +10,4 @@ pytest
 httpx
 fastapi-jwt-auth
 pydantic_settings
+email-validator


### PR DESCRIPTION
## Summary
- pin pydantic to v1 and install email-validator

## Testing
- `pytest -q` *(fails: pyenv version `3.11.9` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863efaeffc0832c9a7f44f3a86e8939