### PR TITLE
Update token generation and remove pydantic-settings

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from pydantic_settings import BaseSettings
+from pydantic import BaseSettings
 
 class Settings(BaseSettings):
     DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@db:5432/postgres"

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -20,5 +20,5 @@ async def login(user_in: UserCreate, session: AsyncSession = Depends(get_session
     user = await auth_service.authenticate_user(session, user_in.email, user_in.password)
     if not user:
         raise HTTPException(status_code=401, detail="Invalid credentials")
-    token = auth_service.create_access_token(str(user.id))
+    token = auth_service.create_access_token({"sub": str(user.id)})
     return {"access_token": token, "token_type": "bearer"}

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import bcrypt
@@ -36,10 +36,16 @@ async def authenticate_user(session: AsyncSession, email: str, password: str) ->
     return user
 
 
-def create_access_token(subject: str, expires_delta: int = settings.ACCESS_TOKEN_EXPIRE_MINUTES) -> str:
-    expire = datetime.utcnow() + timedelta(minutes=expires_delta)
-    to_encode = {"sub": subject, "exp": expire}
-    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    """Create a JWT access token with an expiration time."""
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    return encoded_jwt
 
 async def get_current_user(
     Authorize: AuthJWT = Depends(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ PyJWT
 pytest
 httpx
 fastapi-jwt-auth
-pydantic_settings
+
 email-validator

--- a/tests/test_admin_new.py
+++ b/tests/test_admin_new.py
@@ -22,8 +22,8 @@ async def test_admin_hero_slides_and_promotions_and_dashboard():
         admin.role = "admin"
         user = await create_user(session, "user@test.com", "pass")
         await session.commit()
-        token_admin = create_access_token(str(admin.id))
-        token_user = create_access_token(str(user.id))
+        token_admin = create_access_token({"sub": str(admin.id)})
+        token_user = create_access_token({"sub": str(user.id)})
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         headers_admin = {"Authorization": f"Bearer {token_admin}"}

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -22,8 +22,8 @@ async def test_categories_crud():
         admin.role = "admin"
         user = await create_user(session, "user2@test.com", "pass")
         await session.commit()
-        token_admin = create_access_token(str(admin.id))
-        token_user = create_access_token(str(user.id))
+        token_admin = create_access_token({"sub": str(admin.id)})
+        token_user = create_access_token({"sub": str(user.id)})
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         # unauthorized

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -22,8 +22,8 @@ async def test_orders_flow():
         admin.role = "admin"
         user = await create_user(session, "buyer@test.com", "pass")
         await session.commit()
-        token_admin = create_access_token(str(admin.id))
-        token_user = create_access_token(str(user.id))
+        token_admin = create_access_token({"sub": str(admin.id)})
+        token_user = create_access_token({"sub": str(user.id)})
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         # unauthorized create

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -23,8 +23,8 @@ async def test_products_crud():
         pro = await create_user(session, "pro@test.com", "pass")
         pro.role = "professional"
         await session.commit()
-        token_admin = create_access_token(str(admin.id))
-        token_pro = create_access_token(str(pro.id))
+        token_admin = create_access_token({"sub": str(admin.id)})
+        token_pro = create_access_token({"sub": str(pro.id)})
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         headers_pro = {"Authorization": f"Bearer {token_pro}"}

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -21,7 +21,7 @@ async def test_profile_endpoints():
     async with async_session() as session:
         user = await create_user(session, "profile@test.com", "pass")
         await session.commit()
-        token = create_access_token(str(user.id))
+        token = create_access_token({"sub": str(user.id)})
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         # unauthorized access

--- a/tests/test_promotions.py
+++ b/tests/test_promotions.py
@@ -23,8 +23,8 @@ async def test_promotions_errors_and_crud():
         admin.role = "admin"
         user = await create_user(session, "userp@test.com", "pass")
         await session.commit()
-        token_admin = create_access_token(str(admin.id))
-        token_user = create_access_token(str(user.id))
+        token_admin = create_access_token({"sub": str(admin.id)})
+        token_user = create_access_token({"sub": str(user.id)})
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         valid_data = {

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -21,8 +21,8 @@ async def test_profile_and_admin():
         admin.role = "admin"
         user = await create_user(session, "user@test.com", "pass")
         await session.commit()
-        token_admin = create_access_token(str(admin.id))
-        token_user = create_access_token(str(user.id))
+        token_admin = create_access_token({"sub": str(admin.id)})
+        token_user = create_access_token({"sub": str(user.id)})
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         headers_admin = {"Authorization": f"Bearer {token_admin}"}


### PR DESCRIPTION
## Summary
- drop `pydantic_settings` dependency
- implement new `create_access_token` logic
- adapt auth router and tests to new API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6864100995fc832c8cf7a2dad17eb859