### PR TITLE
Add OAuth2 token retrieval comment

### DIFF
--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -13,6 +13,7 @@ from sqlalchemy.future import select
 from app.models import User
 from app.db.session import get_db
 
+# OAuth2 scheme configuration for token retrieval from requests
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
 SECRET_KEY: str = "change-me"
 ALGORITHM: str = "HS256"


### PR DESCRIPTION
## Summary
- add explanatory comment for OAuth2 token retrieval in auth service

## Testing
- `pytest -q` *(fails: pyenv version `3.11.9` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68651faf7368832c9a72498ed552926d