### PR TITLE
Add CORS middleware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,15 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.routers import api_router
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(api_router)
 
 @app.get('/')


### PR DESCRIPTION
## Summary
- allow any origin via CORS middleware

## Testing
- `pytest -q` *(fails: pyenv could not find requested Python version)*

------
https://chatgpt.com/codex/tasks/task_e_686551b9989c832c85a51cd8b63ddb1b