### PR TITLE
Switch user id to UUID

### DIFF
--- a/alembic/versions/2bee023510cf_user_id_uuid.py
+++ b/alembic/versions/2bee023510cf_user_id_uuid.py
@@ -1,0 +1,28 @@
+"""Switch user id to UUID
+
+Revision ID: 2bee023510cf
+Revises: 521035f7a38f
+Create Date: 2025-07-02 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '2bee023510cf'
+down_revision: Union[str, Sequence[str], None] = '521035f7a38f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column('users', 'id', type_=sa.dialects.postgresql.UUID(), postgresql_using='id::uuid')
+    op.alter_column('orders', 'user_id', type_=sa.dialects.postgresql.UUID(), postgresql_using='user_id::uuid')
+    op.alter_column('products', 'user_id', type_=sa.dialects.postgresql.UUID(), postgresql_using='user_id::uuid')
+
+
+def downgrade() -> None:
+    op.alter_column('products', 'user_id', type_=sa.Integer(), postgresql_using='user_id::integer')
+    op.alter_column('orders', 'user_id', type_=sa.Integer(), postgresql_using='user_id::integer')
+    op.alter_column('users', 'id', type_=sa.Integer(), postgresql_using='id::integer')

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -17,7 +17,7 @@ class Order(Base):
     __tablename__ = "orders"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id = Column(ForeignKey("users.id"), nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     items = Column(JSONB, nullable=False)
     total = Column(Float, nullable=False, default=0.0)
     status = Column(String, nullable=False, default=OrderStatus.pending.value)

--- a/app/models/product.py
+++ b/app/models/product.py
@@ -20,7 +20,7 @@ class Product(Base):
     description = Column(Text, nullable=True)
     price = Column(Float, nullable=False)
     category_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     images = Column(ARRAY(String), nullable=True)
     stock = Column(Integer, nullable=False, default=0)
     status = Column(String, nullable=False, default=ProductStatus.pending.value)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,11 +1,13 @@
+import uuid
 from sqlalchemy import Column, Integer, String, DateTime, Float, Boolean
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 from app.db.session import Base
 
 class User(Base):
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     name = Column(String, nullable=True)
     email = Column(String, unique=True, index=True, nullable=False)
     password_hash = Column(String, nullable=False)

--- a/app/routers/admin/products.py
+++ b/app/routers/admin/products.py
@@ -22,7 +22,7 @@ async def list_products(
     limit: int = 20,
     status: Optional[str] = None,
     category_id: Optional[UUID] = None,
-    user_id: Optional[int] = None,
+    user_id: Optional[UUID] = None,
     session: Session = Depends(get_db),
     admin=Depends(require_role("admin")),
 ):

--- a/app/routers/admin/users.py
+++ b/app/routers/admin/users.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from uuid import UUID
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm import Session
 
@@ -24,7 +25,7 @@ async def list_users(
 
 @router.put("/api/admin/users/{user_id}/status")
 async def update_user_status(
-    user_id: int,
+    user_id: UUID,
     data: StatusUpdate,
     session: Session = Depends(get_db),
     admin=Depends(require_role("admin")),
@@ -34,7 +35,7 @@ async def update_user_status(
 
 @router.put("/api/admin/users/{user_id}/role")
 async def update_user_role(
-    user_id: int,
+    user_id: UUID,
     data: RoleUpdate,
     session: Session = Depends(get_db),
     admin=Depends(require_role("admin")),
@@ -44,7 +45,7 @@ async def update_user_role(
 
 @router.delete("/api/admin/users/{user_id}")
 async def delete_user(
-    user_id: int,
+    user_id: UUID,
     session: Session = Depends(get_db),
     admin=Depends(require_role("admin")),
 ):

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,3 +1,4 @@
+from uuid import UUID
 from pydantic import BaseModel
 
 class UserCreate(BaseModel):
@@ -5,7 +6,7 @@ class UserCreate(BaseModel):
     password: str
 
 class UserOut(BaseModel):
-    id: int
+    id: UUID
     email: str
 
     class Config:

--- a/app/schemas/orders.py
+++ b/app/schemas/orders.py
@@ -13,7 +13,7 @@ class OrderItem(BaseModel):
 
 class OrderBase(BaseModel):
     id: UUID
-    user_id: int
+    user_id: UUID
     items: List[OrderItem]
     total: float
     status: OrderStatus

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -12,7 +12,7 @@ class ProductBase(BaseModel):
     description: Optional[str] = None
     price: float
     category_id: Optional[UUID] = None
-    user_id: Optional[int] = None
+    user_id: Optional[UUID] = None
     images: Optional[List[str]] = None
     stock: int
     status: ProductStatus
@@ -27,7 +27,7 @@ class ProductCreate(BaseModel):
     description: Optional[str] = None
     price: float
     category_id: Optional[UUID] = None
-    user_id: Optional[int] = None
+    user_id: Optional[UUID] = None
     images: Optional[List[str]] = None
     stock: int
     status: Optional[ProductStatus] = ProductStatus.pending

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,9 +1,10 @@
 from typing import Optional, List
 from datetime import datetime
+from uuid import UUID
 from pydantic import BaseModel
 
 class UserBase(BaseModel):
-    id: int
+    id: UUID
     name: Optional[str]
     email: str
     role: str
@@ -35,7 +36,7 @@ class RoleUpdate(BaseModel):
     permissions: Optional[List[str]] = None
 
 class ProfileOut(BaseModel):
-    id: int
+    id: UUID
     name: Optional[str]
     email: str
     is_professional: bool

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -8,6 +8,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 from sqlalchemy.future import select
+from uuid import UUID
 
 
 from app.models import User
@@ -73,7 +74,7 @@ def get_current_user(
     token_data: TokenData = Depends(verify_token),
     session: Session = Depends(get_db),
 ) -> User:
-    result = session.execute(select(User).where(User.id == int(token_data.user_id)))
+    result = session.execute(select(User).where(User.id == UUID(token_data.user_id)))
     user = result.scalars().first()
     if not user:
         raise HTTPException(status_code=401, detail="Invalid token")

--- a/app/services/orders.py
+++ b/app/services/orders.py
@@ -9,7 +9,7 @@ from app.models import Order, OrderStatus
 from app.schemas.orders import OrderCreate, OrderItem
 
 def create_order(
-    session: Session, user_id: int, data: OrderCreate
+    session: Session, user_id: UUID, data: OrderCreate
 ) -> Order:
     items = [item.dict() for item in data.items]
     total = sum(item["price"] * item["quantity"] for item in items)
@@ -21,7 +21,7 @@ def create_order(
 
 def find_all_by_user(
     session: Session,
-    user_id: int,
+    user_id: UUID,
     page: int,
     limit: int,
 ) -> Tuple[List[Order], int]:

--- a/app/services/profile.py
+++ b/app/services/profile.py
@@ -9,7 +9,7 @@ from app.models import User
 from app.schemas.profile import UpdateProfile
 
 
-def get_profile(session: Session, user_id: int) -> User:
+def get_profile(session: Session, user_id: UUID) -> User:
     result = session.execute(select(User).where(User.id == user_id))
     user = result.scalars().first()
     if not user:
@@ -18,7 +18,7 @@ def get_profile(session: Session, user_id: int) -> User:
 
 
 def update_profile(
-    session: Session, user_id: int, data: UpdateProfile
+    session: Session, user_id: UUID, data: UpdateProfile
 ) -> User:
     result = session.execute(select(User).where(User.id == user_id))
     user = result.scalars().first()

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,4 +1,5 @@
 from typing import Optional, Tuple, List
+from uuid import UUID
 
 from sqlalchemy.future import select
 from sqlalchemy import update, delete, func
@@ -28,7 +29,7 @@ def find_all(
     result = session.execute(query.offset((page - 1) * limit).limit(limit))
     return result.scalars().all(), total or 0
 
-def update_status(session: Session, user_id: int, status: str, reason: str) -> None:
+def update_status(session: Session, user_id: UUID, status: str, reason: str) -> None:
     result = session.execute(select(User).where(User.id == user_id))
     user = result.scalars().first()
     if not user:
@@ -36,7 +37,7 @@ def update_status(session: Session, user_id: int, status: str, reason: str) -> N
     user.status = status
     session.commit()
 
-def update_role(session: Session, user_id: int, role: str, permissions: Optional[list]) -> None:
+def update_role(session: Session, user_id: UUID, role: str, permissions: Optional[list]) -> None:
     result = session.execute(select(User).where(User.id == user_id))
     user = result.scalars().first()
     if not user:
@@ -44,11 +45,11 @@ def update_role(session: Session, user_id: int, role: str, permissions: Optional
     user.role = role
     session.commit()
 
-def remove(session: Session, user_id: int) -> None:
+def remove(session: Session, user_id: UUID) -> None:
     session.execute(delete(User).where(User.id == user_id))
     session.commit()
 
-def update_profile(session: Session, user_id: int, name: str, phone: Optional[str], avatar: Optional[str]) -> User:
+def update_profile(session: Session, user_id: UUID, name: str, phone: Optional[str], avatar: Optional[str]) -> User:
     result = session.execute(select(User).where(User.id == user_id))
     user = result.scalars().first()
     if not user:


### PR DESCRIPTION
## Summary
- use UUID primary key for `User`
- adjust references to user_id across models, schemas, services, routers
- add alembic migration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68667b73db7c832c9efabf66e631de8e